### PR TITLE
[Bugfix] xhr API call must use absolute path

### DIFF
--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -41,7 +41,7 @@ prototype(Neos.Neos:Page) {
                     initializeCookieConsent();
                 });
 
-                xhr.open('GET', 'api/kd-gdpr-cc');
+                xhr.open('GET', '/api/kd-gdpr-cc');
                 xhr.send();
             })
         })


### PR DESCRIPTION
For the link for loading the saved cookie consent settings to work properly also on subpages, the AJAX call must use an absolute URL.