### PR TITLE
Get dimension values from site context

### DIFF
--- a/Resources/Private/Fusion/Root.fusion
+++ b/Resources/Private/Fusion/Root.fusion
@@ -9,7 +9,7 @@ prototype(Neos.Neos:Page) {
         package = 'KaufmannDigital.GDPR.CookieConsent'
         controller = 'Api'
         action = 'renderCookieSettings'
-        arguments.dimensions = ${site.dimensions}
+        arguments.dimensions = ${site.context.dimensions}
         absolute = true
     }
 


### PR DESCRIPTION
As described in #23, we also noticed the cookie banner didn't consider dimensions anymore. I tested the bugfix from #24, which unfortunately doesn't work for us. The `/api/kd-gdpr-cc` route is always called with the default dimension value (`language=en` in our case), so the cookie banner always shows in english, even if we're on the german page.

I took some time to debug, and maybe we have messed up our content repository, but calling `site.dimensions` here doesn't consider the current dimension and always returns the default dimension value:
https://github.com/KaufmannDigital/KaufmannDigital.GDPR.CookieConsent/blob/ae3553a2fdddac9cef726778ebe2b02a77854629/Resources/Private/Fusion/Root.fusion#L12

On the other hand calling `site.context.dimensions` returns the correct dimension value with the fallback dimension value. As this part of neos isn't documented very well I'm not sure if that's the right way, but I saw other places in the neos codebase where dimension values are retrieved by calling `site.context.dimensions` rather than `site.dimensions`