### PR TITLE
Bugfix: safari on http does not persist cookie

### DIFF
--- a/Resources/Public/JavaScript/Main.js
+++ b/Resources/Public/JavaScript/Main.js
@@ -218,7 +218,7 @@ function saveConsentToCookie(inputs, userId) {
         expireDate: expireDate.toUTCString()
     };
 
-    var cookieParams = encodeURI(JSON.stringify(cookieData)) + "; expires=" + new Date(currentDate.getTime() + 315360000000).toUTCString() + "; path=/; " + (KD_GDPR_CC.cookieDomainName ? ('domain=' + KD_GDPR_CC.cookieDomainName + ';') : '') +" Secure;";
+    var cookieParams = encodeURI(JSON.stringify(cookieData)) + "; expires=" + new Date(currentDate.getTime() + 315360000000).toUTCString() + "; path=/; " + (KD_GDPR_CC.cookieDomainName ? ('domain=' + KD_GDPR_CC.cookieDomainName + ';') : '') + (location.protocol === 'https' ? " Secure;" : '');
     document.cookie = KD_GDPR_CC.cookieName + "=" + cookieParams;
 
     window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
Safari on HTTP does not persist a cookie when set to secure.

Ran into this during local development.