### PR TITLE
Feature: Exclude for Documents via configurable CookieSettings property

### DIFF
--- a/Configuration/NodeTypes.Content.CookieSettings.yaml
+++ b/Configuration/NodeTypes.Content.CookieSettings.yaml
@@ -142,3 +142,13 @@
           message: i18n
         inspector:
           group: cookieSettings
+    excludedDocuments:
+      type: references
+      ui:
+        inspector:
+          editorOptions:
+            nodeTypes:
+              - 'Neos.Neos:Document'
+          group: cookieSettings
+        label: i18n
+        reloadIfChanged: true

--- a/Resources/Private/Fusion/Helper/JavaScriptSettings.fusion
+++ b/Resources/Private/Fusion/Helper/JavaScriptSettings.fusion
@@ -4,6 +4,7 @@ prototype(KaufmannDigital.GDPR.CookieConsent:Helper.JavaScriptSettings) < protot
     cookieSettingsNode = ${q(site).find('[instanceof KaufmannDigital.GDPR.CookieConsent:Content.CookieSettings]').get(0)}
     @context.versionDate = ${q(this.cookieSettingsNode).property('versionDate')}
     @context.decisionTtl = ${q(this.cookieSettingsNode).property('decisionTtl')}
+    @context.excludedDocuments = ${q(this.cookieSettingsNode).property('excludedDocuments')}
 
     @context.apiUrl = Neos.Fusion:UriBuilder {
         package = 'KaufmannDigital.GDPR.CookieConsent'
@@ -21,7 +22,10 @@ prototype(KaufmannDigital.GDPR.CookieConsent:Helper.JavaScriptSettings) < protot
     @context.cookieName = ${Configuration.setting('KaufmannDigital.GDPR.CookieConsent.cookieName')}
     @context.cookieDomainName = ${Configuration.setting('KaufmannDigital.GDPR.CookieConsent.cookieDomainName')}
 
-    @context.nodeTypeDisabled = ${Array.indexOf(Configuration.setting('KaufmannDigital.GDPR.CookieConsent.excludeDocumentNodeTypes'), documentNode.nodeType.name) >= 0}
+    @context.nodeTypeDisabled = ${
+        Array.indexOf(Configuration.setting('KaufmannDigital.GDPR.CookieConsent.excludeDocumentNodeTypes'), documentNode.nodeType.name) >= 0 ||
+        (excludedDocuments && Array.length(Array.filter(excludedDocuments, (value,key) => value.identifier == documentNode.identifier)) > 0)
+    }
 
     content = ${"
             var KD_GDPR_CC = {

--- a/Resources/Private/Translations/de/NodeTypes/Content/CookieSettings.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/CookieSettings.xlf
@@ -88,6 +88,10 @@
             <trans-unit id="properties.closeButtonEnabled.ui.help.message" xml:space="preserve">
 				<source>Zeigt ein "X" in der oberen rechten Ecke, falls aktiviert. Ein klick auf dieses X schließt den Banner ohne Entscheidung. Er erscheint beim nächsten Seitenaufruf erneut.</source>
 			</trans-unit>
+
+			<trans-unit id="properties.excludedDocuments" xml:space="preserve">
+				<source>Exkludierte Dokumente</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Content/CookieSettings.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Content/CookieSettings.xlf
@@ -70,6 +70,10 @@
             <trans-unit id="properties.closeButtonEnabled.ui.help.message" xml:space="preserve">
 				<source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without making a decision. It re-appears on the next pageload.</source>
 			</trans-unit>
+
+			<trans-unit id="properties.excludedDocuments" xml:space="preserve">
+				<source>Exclude for Documents</source>
+			</trans-unit>
 		</body>
 	</file>
 </xliff>


### PR DESCRIPTION
It is now possible to choose eg Imprint and Legal and don't display the GDPR dialog there