### PR TITLE
BUGFIX: adjust conditions to prevent double insert of script

### DIFF
--- a/Resources/Public/JavaScript/Initialize.js
+++ b/Resources/Public/JavaScript/Initialize.js
@@ -31,7 +31,6 @@ function loadCookiebannerHtml(openSettings, showImmediately, openedManually)
                 }
             });
         }
-        console.log(autoAccept);
 
         if (showImmediately === false && KD_GDPR_CC.hideBeforeInteraction) {
             window.addEventListener(

--- a/Resources/Public/JavaScript/Main.js
+++ b/Resources/Public/JavaScript/Main.js
@@ -168,13 +168,9 @@ function initializeCookieConsent(openSettings, openedManually, autoAccept = 'non
 
     if (openSettings === true) {
         btnIndividualSettingsEnable.dispatchEvent(clickEvent);
-    }
-
-    if (openedManually !== true && autoAccept === 'all') {
+    } else if (openedManually !== true && autoAccept === 'all') {
         btnAcceptAll.dispatchEvent(clickEvent);
-    }
-
-    if (
+    } else if (
         openedManually !== true
         && (typeof KD_GDPR_CC_ACCEPT_NECESSARY !== 'undefined' && KD_GDPR_CC_ACCEPT_NECESSARY === true
             || autoAccept === 'necessary')


### PR DESCRIPTION
These adjustments prevent the api from being requested twice for querying the configured javascript. Currently, when using the gdpr query parameter with the accept-all value, an empty cache entry may be generated on the server side due to the duplicate call and thus no tracking code is downloaded. By adjusting the call conditions in the javascript, a mistakenly triggered api call is avoided and as far as I can see, the tracking javascript code is fetched correctly.