### PR TITLE
Language additions and fixes

### DIFF
--- a/Resources/Private/Fusion/Content/CookieGroup.fusion
+++ b/Resources/Private/Fusion/Content/CookieGroup.fusion
@@ -17,6 +17,7 @@ prototype(KaufmannDigital.GDPR.CookieConsent:Content.CookieGroup) < prototype(Ne
     detailsAvailable = ${q(node).children('cookies').children().count() > 0 || node.context.inBackend}
 
     labels = Neos.Fusion:DataStructure {
+        details = ${I18n.translate('KaufmannDigital.GDPR.CookieConsent:NodeTypes.Content.CookieGroup:details')}
         hideDetails = ${I18n.translate('KaufmannDigital.GDPR.CookieConsent:NodeTypes.Content.CookieGroup:hideDetails')}
     }
 
@@ -37,7 +38,7 @@ prototype(KaufmannDigital.GDPR.CookieConsent:Content.CookieGroup) < prototype(Ne
                 {props.editableDescription}
             </div>
             {props.cookieContentCollection}
-            <a href='#' class="gdpr-cookieconsent-setting-group__details gdpr-cookieconsent-setting-group__details--open" @if.available={props.detailsAvailable} >Details&nbsp;></a>
+            <a href='#' class="gdpr-cookieconsent-setting-group__details gdpr-cookieconsent-setting-group__details--open" @if.available={props.detailsAvailable} >{props.labels.details}</a>
             <a href='#' class="gdpr-cookieconsent-setting-group__details gdpr-cookieconsent-setting-group__details--close hidden" @if.available={props.detailsAvailable} >{props.labels.hideDetails}</a>
         </div>
     `

--- a/Resources/Private/Translations/de/NodeTypes/Content/Cookie.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/Cookie.xlf
@@ -3,22 +3,26 @@
   <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
         target-language="de">
     <body>
-      <trans-unit id="properties.name.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert cookie name...</source>
+      <trans-unit id="properties.name.ui.inline.editorOptions.placeholder">
+        <source>Insert cookie name...</source>
         <target state="final">Cookie Name eintragen ...</target>
-			</trans-unit>
-      <trans-unit id="properties.description.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert cookie description...</source>
+      </trans-unit>
+      <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
+        <source>Insert cookie description...</source>
         <target state="final">Cookie Beschreibung eintragen...</target>
-			</trans-unit>
-      <trans-unit id="properties.priority" xml:space="preserve">
-				<source>Priority</source>
+      </trans-unit>
+      <trans-unit id="properties.priority">
+        <source>Priority</source>
         <target state="final">Priorität</target>
-			</trans-unit>
-      <trans-unit id="properties.priority.ui.help.message" xml:space="preserve">
-        <source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier loading times.</source>
-        <target state="final">Die Priorität bestimmt die Ladereihenfolge der unterschiedlichen Cookies. Höhere Zahlen garantieren frühere Ladezeiten.</target>
-			</trans-unit>
+      </trans-unit>
+      <trans-unit id="properties.priority.ui.help.message">
+        <source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier
+          loading times.
+        </source>
+        <target state="final">Die Priorität bestimmt die Ladereihenfolge der unterschiedlichen Cookies. Höhere Zahlen
+          garantieren frühere Ladezeiten.
+        </target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/de/NodeTypes/Content/Cookie.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/Cookie.xlf
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext" target-language="de">
-		<body>
-			<trans-unit id="properties.name.ui.inline.editorOptions.placeholder" xml:space="preserve">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="de">
+    <body>
+      <trans-unit id="properties.name.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source>Insert cookie name...</source>
-				<target state="final">Cookie Name eintragen ...</target>
+        <target state="final">Cookie Name eintragen ...</target>
 			</trans-unit>
-			<trans-unit id="properties.description.ui.inline.editorOptions.placeholder" xml:space="preserve">
+      <trans-unit id="properties.description.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source>Insert cookie description...</source>
-				<target state="final">Cookie Beschreibung eintragen...</target>
+        <target state="final">Cookie Beschreibung eintragen...</target>
 			</trans-unit>
-			<trans-unit id="properties.priority" xml:space="preserve">
+      <trans-unit id="properties.priority" xml:space="preserve">
 				<source>Priority</source>
-				<target state="final">Priorität</target>
+        <target state="final">Priorität</target>
 			</trans-unit>
-			<trans-unit id="properties.priority.ui.help.message" xml:space="preserve">
-				<source>Die Priorität bestimmt die Ladereihenfolge der unterschiedlichen Cookies. Höhere Zahlen garantieren frühere Ladezeiten.</source>
+      <trans-unit id="properties.priority.ui.help.message" xml:space="preserve">
+        <source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier loading times.</source>
+        <target state="final">Die Priorität bestimmt die Ladereihenfolge der unterschiedlichen Cookies. Höhere Zahlen garantieren frühere Ladezeiten.</target>
 			</trans-unit>
-		</body>
-	</file>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Translations/de/NodeTypes/Content/Cookie/Attribute.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/Cookie/Attribute.xlf
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext" target-language="de">
-		<body>
-			<trans-unit id="ui.label" xml:space="preserve">
-				<source>Cookie Attribute</source>
-				<target state="final">Cookie-Attribut</target>
-			</trans-unit>
-			<trans-unit id="properties.label.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert label...</source>
-			    <target state="final">Label eintragen...</target>
-			</trans-unit>
-			<trans-unit id="properties.value.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert value...</source>
-			    <target state="final">Wert eintragen...</target>
-			</trans-unit>
-		</body>
-	</file>
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="de">
+    <body>
+      <trans-unit id="ui.label">
+        <source>Cookie Attribute</source>
+        <target state="final">Cookie-Attribut</target>
+      </trans-unit>
+      <trans-unit id="properties.label.ui.inline.editorOptions.placeholder">
+        <source>Insert label...</source>
+        <target state="final">Label eintragen...</target>
+      </trans-unit>
+      <trans-unit id="properties.value.ui.inline.editorOptions.placeholder">
+        <source>Insert value...</source>
+        <target state="final">Wert eintragen...</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Translations/de/NodeTypes/Content/CookieGroup.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/CookieGroup.xlf
@@ -18,7 +18,11 @@
 				<source>Insert group description...</source>
 				<target state="final">Gruppenbeschreibung eintragen...</target>
 			</trans-unit>
-            <trans-unit id="hideDetails" xml:space="preserve">
+      <trans-unit id="details" xml:space="preserve">
+				<source><![CDATA[Details&nbsp;>]]></source>
+        <target state="final"><![CDATA[Details&nbsp;>]]></target>
+			</trans-unit>
+      <trans-unit id="hideDetails" xml:space="preserve">
 				<source>Hide details</source>
 				<target state="final">Details ausblenden</target>
 			</trans-unit>

--- a/Resources/Private/Translations/de/NodeTypes/Content/CookieGroup.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/CookieGroup.xlf
@@ -1,31 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext" target-language="de">
-		<body>
-			<trans-unit id="ui.label" xml:space="preserve">
-				<source>Cookie Group</source>
-				<target state="final">Cookie-Gruppe</target>
-			</trans-unit>
-			<trans-unit id="ui.inspector.groups.cookie.label" xml:space="preserve">
-				<source>Cookie Group</source>
-				<target state="final">Cookie-Gruppe</target>
-			</trans-unit>
-			<trans-unit id="properties.headline.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert group title...</source>
-				<target state="final">Gruppenüberschrift eintragen...</target>
-			</trans-unit>
-			<trans-unit id="properties.description.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert group description...</source>
-				<target state="final">Gruppenbeschreibung eintragen...</target>
-			</trans-unit>
-      <trans-unit id="details" xml:space="preserve">
-				<source><![CDATA[Details&nbsp;>]]></source>
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="de">
+    <body>
+      <trans-unit id="ui.label">
+        <source>Cookie Group</source>
+        <target state="final">Cookie-Gruppe</target>
+      </trans-unit>
+      <trans-unit id="ui.inspector.groups.cookie.label">
+        <source>Cookie Group</source>
+        <target state="final">Cookie-Gruppe</target>
+      </trans-unit>
+      <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
+        <source>Insert group title...</source>
+        <target state="final">Gruppenüberschrift eintragen...</target>
+      </trans-unit>
+      <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
+        <source>Insert group description...</source>
+        <target state="final">Gruppenbeschreibung eintragen...</target>
+      </trans-unit>
+      <trans-unit id="details">
+        <source><![CDATA[Details&nbsp;>]]></source>
         <target state="final"><![CDATA[Details&nbsp;>]]></target>
-			</trans-unit>
-      <trans-unit id="hideDetails" xml:space="preserve">
-				<source>Hide details</source>
-				<target state="final">Details ausblenden</target>
-			</trans-unit>
-		</body>
-	</file>
+      </trans-unit>
+      <trans-unit id="hideDetails">
+        <source>Hide details</source>
+        <target state="final">Details ausblenden</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Translations/de/NodeTypes/Content/CookieSettings.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/CookieSettings.xlf
@@ -1,116 +1,111 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext" target-language="de">
-		<body>
-			<trans-unit id="ui.label" xml:space="preserve">
-				<source>Cookie Settings</source>
-				<target state="final">Cookie Einstellungen</target>
-			</trans-unit>
-			<trans-unit id="ui.inspector.groups.cookieSettings.label" xml:space="preserve">
-				<source>Cookie Settings</source>
-				<target state="final">Cookie Einstellungen</target>
-			</trans-unit>
-			<trans-unit id="properties.headline.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert title...</source>
-				<target state="final">Überschrift eintragen...</target>
-			</trans-unit>
-			<trans-unit id="properties.mainDescription.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert description...</source>
-				<target state="final">Beschreibung eintragen...</target>
-			</trans-unit>
-			<trans-unit id="properties.individualSettingsDescription.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert description...</source>
-				<target state="final">Beschreibung eintragen...</target>
-			</trans-unit>
-			<trans-unit id="properties.imprintLink" xml:space="preserve">
-				<source>Link to imprint</source>
-				<target state="final">Link zum Impressum</target>
-			</trans-unit>
-			<trans-unit id="properties.dataProtectionPolicyLink" xml:space="preserve">
-				<source>Link to data protection policy</source>
-				<target state="final">Link zur Datenschutzerklärung</target>
-			</trans-unit>
-			<trans-unit id="properties.acceptAllButtonLabel" xml:space="preserve">
-				<source>"Accept all" label</source>
-				<target state="final">Label "Alle akzeptieren"</target>
-			</trans-unit>
-
-			<trans-unit id="properties.saveButtonLabel" xml:space="preserve">
-				<source>"Save" label</source>
-				<target state="final">Label "Speichern"</target>
-			</trans-unit>
-
-			<trans-unit id="properties.acceptNecessaryCookiesLabel" xml:space="preserve">
-				<source>"Accept necessary cookies" label</source>
-				<target state="final">Label "Notwendige Cookies akzeptieren"</target>
-			</trans-unit>
-
-			<trans-unit id="properties.imprintLabel" xml:space="preserve">
-				<source>"Imprint" label</source>
-				<target state="final">Label "Impressum"</target>
-			</trans-unit>
-
-			<trans-unit id="properties.dataProtectionPolicyLabel" xml:space="preserve">
-				<source>"Data protection policy" label</source>
-				<target state="final">Label "Datenschutzerklärung"</target>
-			</trans-unit>
-
-			<trans-unit id="properties.openIndividualSettingsLabel" xml:space="preserve">
-				<source>"Individual settings" label</source>
-				<target state="final">Label "Individuelle Einstellungen"</target>
-			</trans-unit>
-
-			<trans-unit id="properties.closeIndividualSettingsLabel" xml:space="preserve">
-				<source>"Close settings" label</source>
-				<target state="final">Label "Einstellungen schließen"</target>
-			</trans-unit>
-
-			<trans-unit id="properties.versionDate" xml:space="preserve">
-				<source>Version date</source>
-				<target state="final">Versions-Datum</target>
-			</trans-unit>
-
-            <trans-unit id="properties.decisionTtl" xml:space="preserve">
-				<source>TTL (Decision time in seconds)</source>
-                <target state="final">TTL (Speicherdauer der Entscheidung in Sekunden)</target>
-			</trans-unit>
-
-            <trans-unit id="properties.decisionTtl.ui.help.message" xml:space="preserve">
-				<source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1 day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)</source>
-                <target state="final">Anzahl der Sekunden, bis die Cookie-Einstellungen erneut angezeigt und bestätigt werden. Beispielwerte sind: 86400 (1 Tag), 604800 (1 Woche), 2592000 (30 Tage), 31536000 (1 Jahr)</target>
-			</trans-unit>
-
-            <trans-unit id="properties.closeButtonEnabled" xml:space="preserve">
-				<source>Show close-button</source>
-                <target state="final">Zeige X (zum schließen)</target>
-			</trans-unit>
-
-            <trans-unit id="properties.closeButtonEnabled.ui.help.message" xml:space="preserve">
-				<source>Zeigt ein "X" in der oberen rechten Ecke, falls aktiviert. Ein klick auf dieses X schließt den Banner ohne Entscheidung. Er erscheint beim nächsten Seitenaufruf erneut.</source>
-			</trans-unit>
-
-			<trans-unit id="properties.excludedDocuments" xml:space="preserve">
-				<source>Exkludierte Dokumente</source>
-			</trans-unit>
-
-			<trans-unit id="properties.buttonTextColor.selectBoxEditor.values.white" xml:space="preserve">
-				<source>Weiß</source>
-			</trans-unit>
-			<trans-unit id="properties.buttonTextColor.selectBoxEditor.values.black" xml:space="preserve">
-				<source>Schwarz</source>
-			</trans-unit>
-			<trans-unit id="properties.backgroundColor" xml:space="preserve">
-				<source>Hintergrundfarbe (HEX)</source>
-			</trans-unit>
-			<trans-unit id="properties.buttonTextColor" xml:space="preserve">
-				<source>Button Textfarbe</source>
-			</trans-unit>
-			<trans-unit id="properties.themeColor" xml:space="preserve">
-				<source>Theme-Farbe (HEX)</source>
-			</trans-unit>
-			<trans-unit id="properties.maxWidth" xml:space="preserve">
-				<source>Maximale Breite für Inhalte (px)</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="de">
+    <body>
+      <trans-unit id="ui.label">
+        <source>Cookie Settings</source>
+        <target state="final">Cookie Einstellungen</target>
+      </trans-unit>
+      <trans-unit id="ui.inspector.groups.cookieSettings.label">
+        <source>Cookie Settings</source>
+        <target state="final">Cookie Einstellungen</target>
+      </trans-unit>
+      <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
+        <source>Insert title...</source>
+        <target state="final">Überschrift eintragen...</target>
+      </trans-unit>
+      <trans-unit id="properties.mainDescription.ui.inline.editorOptions.placeholder">
+        <source>Insert description...</source>
+        <target state="final">Beschreibung eintragen...</target>
+      </trans-unit>
+      <trans-unit id="properties.individualSettingsDescription.ui.inline.editorOptions.placeholder">
+        <source>Insert description...</source>
+        <target state="final">Beschreibung eintragen...</target>
+      </trans-unit>
+      <trans-unit id="properties.imprintLink">
+        <source>Link to imprint</source>
+        <target state="final">Link zum Impressum</target>
+      </trans-unit>
+      <trans-unit id="properties.dataProtectionPolicyLink">
+        <source>Link to data protection policy</source>
+        <target state="final">Link zur Datenschutzerklärung</target>
+      </trans-unit>
+      <trans-unit id="properties.acceptAllButtonLabel">
+        <source>"Accept all" label</source>
+        <target state="final">Label "Alle akzeptieren"</target>
+      </trans-unit>
+      <trans-unit id="properties.saveButtonLabel">
+        <source>"Save" label</source>
+        <target state="final">Label "Speichern"</target>
+      </trans-unit>
+      <trans-unit id="properties.acceptNecessaryCookiesLabel">
+        <source>"Accept necessary cookies" label</source>
+        <target state="final">Label "Notwendige Cookies akzeptieren"</target>
+      </trans-unit>
+      <trans-unit id="properties.imprintLabel">
+        <source>"Imprint" label</source>
+        <target state="final">Label "Impressum"</target>
+      </trans-unit>
+      <trans-unit id="properties.dataProtectionPolicyLabel">
+        <source>"Data protection policy" label</source>
+        <target state="final">Label "Datenschutzerklärung"</target>
+      </trans-unit>
+      <trans-unit id="properties.openIndividualSettingsLabel">
+        <source>"Individual settings" label</source>
+        <target state="final">Label "Individuelle Einstellungen"</target>
+      </trans-unit>
+      <trans-unit id="properties.closeIndividualSettingsLabel">
+        <source>"Close settings" label</source>
+        <target state="final">Label "Einstellungen schließen"</target>
+      </trans-unit>
+      <trans-unit id="properties.versionDate">
+        <source>Version date</source>
+        <target state="final">Versions-Datum</target>
+      </trans-unit>
+      <trans-unit id="properties.decisionTtl">
+        <source>TTL (Decision time in seconds)</source>
+        <target state="final">TTL (Speicherdauer der Entscheidung in Sekunden)</target>
+      </trans-unit>
+      <trans-unit id="properties.decisionTtl.ui.help.message">
+        <source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1 day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)</source>
+        <target state="final">Anzahl der Sekunden, bis die Cookie-Einstellungen erneut angezeigt und bestätigt werden. Beispielwerte sind: 86400 (1 Tag), 604800 (1 Woche), 2592000 (30 Tage), 31536000 (1 Jahr)</target>
+      </trans-unit>
+      <trans-unit id="properties.closeButtonEnabled">
+        <source>Show close-button</source>
+        <target state="final">Zeige X (zum schließen)</target>
+      </trans-unit>
+      <trans-unit id="properties.closeButtonEnabled.ui.help.message">
+        <source>Zeigt ein "X" in der oberen rechten Ecke, falls aktiviert. Ein klick auf dieses X schließt den Banner ohne Entscheidung. Er erscheint beim nächsten Seitenaufruf erneut.</source>
+      </trans-unit>
+      <trans-unit id="properties.excludedDocuments">
+        <source>Exclude for Documents</source>
+        <target state="final">Exkludierte Dokumente</target>
+      </trans-unit>
+      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.white">
+        <source>White</source>
+        <target state="final">Weiß</target>
+      </trans-unit>
+      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.black">
+        <source>Black</source>
+        <target state="final">Schwarz</target>
+      </trans-unit>
+      <trans-unit id="properties.backgroundColor">
+        <source>Background color (HEX)</source>
+        <target state="final">Hintergrundfarbe (HEX)</target>
+      </trans-unit>
+      <trans-unit id="properties.buttonTextColor">
+        <source>Button text color</source>
+        <target state="final">Button Textfarbe</target>
+      </trans-unit>
+      <trans-unit id="properties.themeColor">
+        <source>Theme color (HEX)</source>
+        <target state="final">Theme-Farbe (HEX)</target>
+      </trans-unit>
+      <trans-unit id="properties.maxWidth">
+        <source>Maximum content width (px)</source>
+        <target state="final">Maximale Breite für Inhalte (px)</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Translations/de/NodeTypes/Content/CookieSettings.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/CookieSettings.xlf
@@ -68,15 +68,21 @@
         <target state="final">TTL (Speicherdauer der Entscheidung in Sekunden)</target>
       </trans-unit>
       <trans-unit id="properties.decisionTtl.ui.help.message">
-        <source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1 day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)</source>
-        <target state="final">Anzahl der Sekunden, bis die Cookie-Einstellungen erneut angezeigt und bestätigt werden. Beispielwerte sind: 86400 (1 Tag), 604800 (1 Woche), 2592000 (30 Tage), 31536000 (1 Jahr)</target>
+        <source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1
+          day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)
+        </source>
+        <target state="final">Anzahl der Sekunden, bis die Cookie-Einstellungen erneut angezeigt und bestätigt werden.
+          Beispielwerte sind: 86400 (1 Tag), 604800 (1 Woche), 2592000 (30 Tage), 31536000 (1 Jahr)
+        </target>
       </trans-unit>
       <trans-unit id="properties.closeButtonEnabled">
         <source>Show close-button</source>
         <target state="final">Zeige X (zum schließen)</target>
       </trans-unit>
       <trans-unit id="properties.closeButtonEnabled.ui.help.message">
-        <source>Zeigt ein "X" in der oberen rechten Ecke, falls aktiviert. Ein klick auf dieses X schließt den Banner ohne Entscheidung. Er erscheint beim nächsten Seitenaufruf erneut.</source>
+        <source>Zeigt ein "X" in der oberen rechten Ecke, falls aktiviert. Ein klick auf dieses X schließt den Banner
+          ohne Entscheidung. Er erscheint beim nächsten Seitenaufruf erneut.
+        </source>
       </trans-unit>
       <trans-unit id="properties.excludedDocuments">
         <source>Exclude for Documents</source>

--- a/Resources/Private/Translations/de/NodeTypes/Content/NecessarySettingGroup.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Content/NecessarySettingGroup.xlf
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext" target-language="de">
-		<body>
-			<trans-unit id="ui.label" xml:space="preserve">
-				<source>Necessary Cookies Group</source>
-				<target state="final">Notwendige Cookies-Gruppe</target>
-			</trans-unit>
-		</body>
-	</file>
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="de">
+    <body>
+      <trans-unit id="ui.label">
+        <source>Necessary Cookies Group</source>
+        <target state="final">Notwendige Cookies-Gruppe</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Translations/de/NodeTypes/Document/CookieSettingsPage.xlf
+++ b/Resources/Private/Translations/de/NodeTypes/Document/CookieSettingsPage.xlf
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext" target-language="de">
-		<body>
-			<trans-unit id="ui.label" xml:space="preserve">
-				<source>Cookie Settings Page</source>
-				<target state="final">Cookie Einstellungen</target>
-			</trans-unit>
-		</body>
-	</file>
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="de">
+    <body>
+      <trans-unit id="ui.label">
+        <source>Cookie Settings Page</source>
+        <target state="final">Cookie Einstellungen</target>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Content/Cookie.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Content/Cookie.xlf
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
-		<body>
-			<trans-unit id="properties.name.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert cookie name...</source>
-			</trans-unit>
-			<trans-unit id="properties.description.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert cookie description...</source>
-			</trans-unit>
-			<trans-unit id="properties.priority" xml:space="preserve">
-				<source>Priority</source>
-			</trans-unit>
-			<trans-unit id="properties.priority.ui.help.message" xml:space="preserve">
-				<source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier loading times.</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="properties.name.ui.inline.editorOptions.placeholder">
+        <source>Insert cookie name...</source>
+      </trans-unit>
+      <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
+        <source>Insert cookie description...</source>
+      </trans-unit>
+      <trans-unit id="properties.priority">
+        <source>Priority</source>
+      </trans-unit>
+      <trans-unit id="properties.priority.ui.help.message">
+        <source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier
+          loading times.
+        </source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Content/Cookie/Attribute.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Content/Cookie/Attribute.xlf
@@ -1,16 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
-		<body>
-			<trans-unit id="ui.label" xml:space="preserve">
-				<source>Cookie Attribute</source>
-			</trans-unit>
-			<trans-unit id="properties.label.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert label...</source>
-			</trans-unit>
-			<trans-unit id="properties.value.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert value...</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ui.label">
+        <source>Cookie Attribute</source>
+      </trans-unit>
+      <trans-unit id="properties.label.ui.inline.editorOptions.placeholder">
+        <source>Insert label...</source>
+      </trans-unit>
+      <trans-unit id="properties.value.ui.inline.editorOptions.placeholder">
+        <source>Insert value...</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Content/CookieGroup.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Content/CookieGroup.xlf
@@ -1,26 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
-		<body>
-			<trans-unit id="ui.label" xml:space="preserve">
-				<source>Cookie Group</source>
-			</trans-unit>
-			<trans-unit id="ui.inspector.groups.cookie.label" xml:space="preserve">
-				<source>Cookie Group</source>
-			</trans-unit>
-			<trans-unit id="properties.headline.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert group title...</source>
-			</trans-unit>
-			<trans-unit id="properties.description.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert group description...</source>
-			</trans-unit>
-			<trans-unit id="details" xml:space="preserve">
-				<source><![CDATA[Details&nbsp;>]]></source>
-			</trans-unit>
-      <trans-unit id="hideDetails" xml:space="preserve">
-				<source>Hide details</source>
-			</trans-unit>
-
-		</body>
-	</file>
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ui.label">
+        <source>Cookie Group</source>
+      </trans-unit>
+      <trans-unit id="ui.inspector.groups.cookie.label">
+        <source>Cookie Group</source>
+      </trans-unit>
+      <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
+        <source>Insert group title...</source>
+      </trans-unit>
+      <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
+        <source>Insert group description...</source>
+      </trans-unit>
+      <trans-unit id="details">
+        <source><![CDATA[Details&nbsp;>]]></source>
+      </trans-unit>
+      <trans-unit id="hideDetails">
+        <source>Hide details</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Content/CookieGroup.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Content/CookieGroup.xlf
@@ -14,7 +14,10 @@
 			<trans-unit id="properties.description.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source>Insert group description...</source>
 			</trans-unit>
-			<trans-unit id="hideDetails" xml:space="preserve">
+			<trans-unit id="details" xml:space="preserve">
+				<source><![CDATA[Details&nbsp;>]]></source>
+			</trans-unit>
+      <trans-unit id="hideDetails" xml:space="preserve">
 				<source>Hide details</source>
 			</trans-unit>
 

--- a/Resources/Private/Translations/en/NodeTypes/Content/CookieSettings.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Content/CookieSettings.xlf
@@ -1,98 +1,99 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
-		<body>
-			<trans-unit id="ui.label" xml:space="preserve">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ui.label" xml:space="preserve">
 				<source>Cookie Settings</source>
 			</trans-unit>
-			<trans-unit id="ui.inspector.groups.cookieSettings.label" xml:space="preserve">
+      <trans-unit id="ui.inspector.groups.cookieSettings.label" xml:space="preserve">
 				<source>Cookie Settings</source>
 			</trans-unit>
-			<trans-unit id="properties.headline.ui.inline.editorOptions.placeholder" xml:space="preserve">
+      <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source>Insert title...</source>
 			</trans-unit>
-			<trans-unit id="properties.mainDescription.ui.inline.editorOptions.placeholder" xml:space="preserve">
+      <trans-unit id="properties.mainDescription.ui.inline.editorOptions.placeholder" xml:space="preserve">
 				<source>Insert description...</source>
 			</trans-unit>
-			<trans-unit id="properties.individualSettingsDescription.ui.inline.editorOptions.placeholder" xml:space="preserve">
+      <trans-unit id="properties.individualSettingsDescription.ui.inline.editorOptions.placeholder"
+                  xml:space="preserve">
 				<source>Insert description...</source>
 			</trans-unit>
-			<trans-unit id="properties.imprintLink" xml:space="preserve">
+      <trans-unit id="properties.imprintLink" xml:space="preserve">
 				<source>Link to imprint</source>
 			</trans-unit>
-			<trans-unit id="properties.dataProtectionPolicyLink" xml:space="preserve">
+      <trans-unit id="properties.dataProtectionPolicyLink" xml:space="preserve">
 				<source>Link to data protection policy</source>
 			</trans-unit>
-			<trans-unit id="properties.acceptAllButtonLabel" xml:space="preserve">
+      <trans-unit id="properties.acceptAllButtonLabel" xml:space="preserve">
 				<source>"Accept all" label</source>
 			</trans-unit>
 
-			<trans-unit id="properties.saveButtonLabel" xml:space="preserve">
+      <trans-unit id="properties.saveButtonLabel" xml:space="preserve">
 				<source>"Save" label</source>
 			</trans-unit>
 
-			<trans-unit id="properties.acceptNecessaryCookiesLabel" xml:space="preserve">
+      <trans-unit id="properties.acceptNecessaryCookiesLabel" xml:space="preserve">
 				<source>"Accept necessary cookies" label</source>
 			</trans-unit>
 
-			<trans-unit id="properties.imprintLabel" xml:space="preserve">
+      <trans-unit id="properties.imprintLabel" xml:space="preserve">
 				<source>"Imprint" label</source>
 			</trans-unit>
 
-			<trans-unit id="properties.dataProtectionPolicyLabel" xml:space="preserve">
+      <trans-unit id="properties.dataProtectionPolicyLabel" xml:space="preserve">
 				<source>"Data protection policy" label</source>
 			</trans-unit>
 
-			<trans-unit id="properties.openIndividualSettingsLabel" xml:space="preserve">
+      <trans-unit id="properties.openIndividualSettingsLabel" xml:space="preserve">
 				<source>"Individual settings" label</source>
 			</trans-unit>
 
-			<trans-unit id="properties.closeIndividualSettingsLabel" xml:space="preserve">
+      <trans-unit id="properties.closeIndividualSettingsLabel" xml:space="preserve">
 				<source>"Close settings" label</source>
 			</trans-unit>
 
-			<trans-unit id="properties.versionDate" xml:space="preserve">
+      <trans-unit id="properties.versionDate" xml:space="preserve">
 				<source>Version date</source>
 			</trans-unit>
 
-            <trans-unit id="properties.decisionTtl" xml:space="preserve">
+      <trans-unit id="properties.decisionTtl" xml:space="preserve">
 				<source>TTL (Decision time in seconds)</source>
 			</trans-unit>
 
-            <trans-unit id="properties.decisionTtl.ui.help.message" xml:space="preserve">
+      <trans-unit id="properties.decisionTtl.ui.help.message" xml:space="preserve">
 				<source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1 day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)</source>
 			</trans-unit>
 
-            <trans-unit id="properties.closeButtonEnabled" xml:space="preserve">
+      <trans-unit id="properties.closeButtonEnabled" xml:space="preserve">
 				<source>Show close-button</source>
 			</trans-unit>
 
-            <trans-unit id="properties.closeButtonEnabled.ui.help.message" xml:space="preserve">
+      <trans-unit id="properties.closeButtonEnabled.ui.help.message" xml:space="preserve">
 				<source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without making a decision. It re-appears on the next pageload.</source>
 			</trans-unit>
 
-			<trans-unit id="properties.excludedDocuments" xml:space="preserve">
+      <trans-unit id="properties.excludedDocuments" xml:space="preserve">
 				<source>Exclude for Documents</source>
 			</trans-unit>
 
-			<trans-unit id="properties.buttonTextColor.selectBoxEditor.values.white" xml:space="preserve">
+      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.white" xml:space="preserve">
 				<source>White</source>
 			</trans-unit>
-			<trans-unit id="properties.buttonTextColor.selectBoxEditor.values.black" xml:space="preserve">
+      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.black" xml:space="preserve">
 				<source>Black</source>
 			</trans-unit>
-			<trans-unit id="properties.backgroundColor" xml:space="preserve">
+      <trans-unit id="properties.backgroundColor" xml:space="preserve">
 				<source>Background color (HEX)</source>
 			</trans-unit>
-			<trans-unit id="properties.buttonTextColor" xml:space="preserve">
+      <trans-unit id="properties.buttonTextColor" xml:space="preserve">
 				<source>Button text color</source>
 			</trans-unit>
-			<trans-unit id="properties.themeColor" xml:space="preserve">
+      <trans-unit id="properties.themeColor" xml:space="preserve">
 				<source>Theme color (HEX)</source>
 			</trans-unit>
-			<trans-unit id="properties.maxWidth" xml:space="preserve">
-                <source>Maximum content width (px)</source>
-            </trans-unit>
-		</body>
-	</file>
+      <trans-unit id="properties.maxWidth" xml:space="preserve">
+        <source>Maximum content width (px)</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Content/CookieSettings.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Content/CookieSettings.xlf
@@ -2,96 +2,86 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
     <body>
-      <trans-unit id="ui.label" xml:space="preserve">
-				<source>Cookie Settings</source>
-			</trans-unit>
-      <trans-unit id="ui.inspector.groups.cookieSettings.label" xml:space="preserve">
-				<source>Cookie Settings</source>
-			</trans-unit>
-      <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert title...</source>
-			</trans-unit>
-      <trans-unit id="properties.mainDescription.ui.inline.editorOptions.placeholder" xml:space="preserve">
-				<source>Insert description...</source>
-			</trans-unit>
-      <trans-unit id="properties.individualSettingsDescription.ui.inline.editorOptions.placeholder"
-                  xml:space="preserve">
-				<source>Insert description...</source>
-			</trans-unit>
-      <trans-unit id="properties.imprintLink" xml:space="preserve">
-				<source>Link to imprint</source>
-			</trans-unit>
-      <trans-unit id="properties.dataProtectionPolicyLink" xml:space="preserve">
-				<source>Link to data protection policy</source>
-			</trans-unit>
-      <trans-unit id="properties.acceptAllButtonLabel" xml:space="preserve">
-				<source>"Accept all" label</source>
-			</trans-unit>
-
-      <trans-unit id="properties.saveButtonLabel" xml:space="preserve">
-				<source>"Save" label</source>
-			</trans-unit>
-
-      <trans-unit id="properties.acceptNecessaryCookiesLabel" xml:space="preserve">
-				<source>"Accept necessary cookies" label</source>
-			</trans-unit>
-
-      <trans-unit id="properties.imprintLabel" xml:space="preserve">
-				<source>"Imprint" label</source>
-			</trans-unit>
-
-      <trans-unit id="properties.dataProtectionPolicyLabel" xml:space="preserve">
-				<source>"Data protection policy" label</source>
-			</trans-unit>
-
-      <trans-unit id="properties.openIndividualSettingsLabel" xml:space="preserve">
-				<source>"Individual settings" label</source>
-			</trans-unit>
-
-      <trans-unit id="properties.closeIndividualSettingsLabel" xml:space="preserve">
-				<source>"Close settings" label</source>
-			</trans-unit>
-
-      <trans-unit id="properties.versionDate" xml:space="preserve">
-				<source>Version date</source>
-			</trans-unit>
-
-      <trans-unit id="properties.decisionTtl" xml:space="preserve">
-				<source>TTL (Decision time in seconds)</source>
-			</trans-unit>
-
-      <trans-unit id="properties.decisionTtl.ui.help.message" xml:space="preserve">
-				<source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1 day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)</source>
-			</trans-unit>
-
-      <trans-unit id="properties.closeButtonEnabled" xml:space="preserve">
-				<source>Show close-button</source>
-			</trans-unit>
-
-      <trans-unit id="properties.closeButtonEnabled.ui.help.message" xml:space="preserve">
-				<source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without making a decision. It re-appears on the next pageload.</source>
-			</trans-unit>
-
-      <trans-unit id="properties.excludedDocuments" xml:space="preserve">
-				<source>Exclude for Documents</source>
-			</trans-unit>
-
-      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.white" xml:space="preserve">
-				<source>White</source>
-			</trans-unit>
-      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.black" xml:space="preserve">
-				<source>Black</source>
-			</trans-unit>
-      <trans-unit id="properties.backgroundColor" xml:space="preserve">
-				<source>Background color (HEX)</source>
-			</trans-unit>
-      <trans-unit id="properties.buttonTextColor" xml:space="preserve">
-				<source>Button text color</source>
-			</trans-unit>
-      <trans-unit id="properties.themeColor" xml:space="preserve">
-				<source>Theme color (HEX)</source>
-			</trans-unit>
-      <trans-unit id="properties.maxWidth" xml:space="preserve">
+      <trans-unit id="ui.label">
+        <source>Cookie Settings</source>
+      </trans-unit>
+      <trans-unit id="ui.inspector.groups.cookieSettings.label">
+        <source>Cookie Settings</source>
+      </trans-unit>
+      <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
+        <source>Insert title...</source>
+      </trans-unit>
+      <trans-unit id="properties.mainDescription.ui.inline.editorOptions.placeholder">
+        <source>Insert description...</source>
+      </trans-unit>
+      <trans-unit id="properties.individualSettingsDescription.ui.inline.editorOptions.placeholder">
+        <source>Insert description...</source>
+      </trans-unit>
+      <trans-unit id="properties.imprintLink">
+        <source>Link to imprint</source>
+      </trans-unit>
+      <trans-unit id="properties.dataProtectionPolicyLink">
+        <source>Link to data protection policy</source>
+      </trans-unit>
+      <trans-unit id="properties.acceptAllButtonLabel">
+        <source>"Accept all" label</source>
+      </trans-unit>
+      <trans-unit id="properties.saveButtonLabel">
+        <source>"Save" label</source>
+      </trans-unit>
+      <trans-unit id="properties.acceptNecessaryCookiesLabel">
+        <source>"Accept necessary cookies" label</source>
+      </trans-unit>
+      <trans-unit id="properties.imprintLabel">
+        <source>"Imprint" label</source>
+      </trans-unit>
+      <trans-unit id="properties.dataProtectionPolicyLabel">
+        <source>"Data protection policy" label</source>
+      </trans-unit>
+      <trans-unit id="properties.openIndividualSettingsLabel">
+        <source>"Individual settings" label</source>
+      </trans-unit>
+      <trans-unit id="properties.closeIndividualSettingsLabel">
+        <source>"Close settings" label</source>
+      </trans-unit>
+      <trans-unit id="properties.versionDate">
+        <source>Version date</source>
+      </trans-unit>
+      <trans-unit id="properties.decisionTtl">
+        <source>TTL (Decision time in seconds)</source>
+      </trans-unit>
+      <trans-unit id="properties.decisionTtl.ui.help.message">
+        <source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1
+          day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)
+        </source>
+      </trans-unit>
+      <trans-unit id="properties.closeButtonEnabled">
+        <source>Show close-button</source>
+      </trans-unit>
+      <trans-unit id="properties.closeButtonEnabled.ui.help.message">
+        <source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without
+          making a decision. It re-appears on the next pageload.
+        </source>
+      </trans-unit>
+      <trans-unit id="properties.excludedDocuments">
+        <source>Exclude for Documents</source>
+      </trans-unit>
+      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.white">
+        <source>White</source>
+      </trans-unit>
+      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.black">
+        <source>Black</source>
+      </trans-unit>
+      <trans-unit id="properties.backgroundColor">
+        <source>Background color (HEX)</source>
+      </trans-unit>
+      <trans-unit id="properties.buttonTextColor">
+        <source>Button text color</source>
+      </trans-unit>
+      <trans-unit id="properties.themeColor">
+        <source>Theme color (HEX)</source>
+      </trans-unit>
+      <trans-unit id="properties.maxWidth">
         <source>Maximum content width (px)</source>
       </trans-unit>
     </body>

--- a/Resources/Private/Translations/en/NodeTypes/Content/NecessarySettingGroup.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Content/NecessarySettingGroup.xlf
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
-		<body>
-			<trans-unit id="ui.label" xml:space="preserve">
-				<source>Necessary Cookies Group</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ui.label">
+        <source>Necessary Cookies Group</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Translations/en/NodeTypes/Document/CookieSettingsPage.xlf
+++ b/Resources/Private/Translations/en/NodeTypes/Document/CookieSettingsPage.xlf
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-	<file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
-		<body>
-			<trans-unit id="ui.label" xml:space="preserve">
-				<source>Cookie Settings Page</source>
-			</trans-unit>
-		</body>
-	</file>
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext">
+    <body>
+      <trans-unit id="ui.label">
+        <source>Cookie Settings Page</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Translations/es/NodeTypes/Content/Cookie.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/Content/Cookie.xlf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="es">
+    <body>
+      <trans-unit id="properties.name.ui.inline.editorOptions.placeholder">
+				<source>Insert cookie name...</source>
+        <target state="final">Introduzca el nombre de la cookie ...</target>
+			</trans-unit>
+      <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
+				<source>Insert cookie description...</source>
+        <target state="final">Introduzca la descripción de la cookie...</target>
+			</trans-unit>
+      <trans-unit id="properties.priority">
+				<source>Priority</source>
+        <target state="final">Prioridad</target>
+			</trans-unit>
+      <trans-unit id="properties.priority.ui.help.message">
+				<source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier loading times.</source>
+        <target>La prioridad determina el orden de carga de las diferentes cookies. Los números más altos garantizan tiempos de carga más rápidos.</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/es/NodeTypes/Content/Cookie.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/Content/Cookie.xlf
@@ -4,21 +4,25 @@
         target-language="es">
     <body>
       <trans-unit id="properties.name.ui.inline.editorOptions.placeholder">
-				<source>Insert cookie name...</source>
+        <source>Insert cookie name...</source>
         <target state="final">Introduzca el nombre de la cookie ...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
-				<source>Insert cookie description...</source>
+        <source>Insert cookie description...</source>
         <target state="final">Introduzca la descripción de la cookie...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.priority">
-				<source>Priority</source>
+        <source>Priority</source>
         <target state="final">Prioridad</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.priority.ui.help.message">
-				<source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier loading times.</source>
-        <target>La prioridad determina el orden de carga de las diferentes cookies. Los números más altos garantizan tiempos de carga más rápidos.</target>
-			</trans-unit>
+        <source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier
+          loading times.
+        </source>
+        <target>La prioridad determina el orden de carga de las diferentes cookies. Los números más altos garantizan
+          tiempos de carga más rápidos.
+        </target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/es/NodeTypes/Content/Cookie/Attribute.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/Content/Cookie/Attribute.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="es">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Cookie Attribute</source>
+        <target state="final">Función de cookies</target>
+			</trans-unit>
+      <trans-unit id="properties.label.ui.inline.editorOptions.placeholder">
+				<source>Insert label...</source>
+        <target state="final">Introducir etiqueta...</target>
+			</trans-unit>
+      <trans-unit id="properties.value.ui.inline.editorOptions.placeholder">
+				<source>Insert value...</source>
+        <target state="final">Introducir valor...</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/es/NodeTypes/Content/Cookie/Attribute.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/Content/Cookie/Attribute.xlf
@@ -4,17 +4,17 @@
         target-language="es">
     <body>
       <trans-unit id="ui.label">
-				<source>Cookie Attribute</source>
+        <source>Cookie Attribute</source>
         <target state="final">Función de cookies</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.label.ui.inline.editorOptions.placeholder">
-				<source>Insert label...</source>
+        <source>Insert label...</source>
         <target state="final">Introducir etiqueta...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.value.ui.inline.editorOptions.placeholder">
-				<source>Insert value...</source>
+        <source>Insert value...</source>
         <target state="final">Introducir valor...</target>
-			</trans-unit>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/es/NodeTypes/Content/CookieGroup.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/Content/CookieGroup.xlf
@@ -4,29 +4,29 @@
         target-language="es">
     <body>
       <trans-unit id="ui.label">
-				<source>Cookie Group</source>
+        <source>Cookie Group</source>
         <target state="final">Grupo de cookies</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="ui.inspector.groups.cookie.label">
-				<source>Cookie Group</source>
+        <source>Cookie Group</source>
         <target state="final">Grupo de cookies</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
-				<source>Insert group title...</source>
+        <source>Insert group title...</source>
         <target state="final">Insertar título del grupo...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
-				<source>Insert group description...</source>
+        <source>Insert group description...</source>
         <target state="final">Introduzca la descripción del grupo...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="details">
-				<source><![CDATA[Details&nbsp;>]]></source>
+        <source><![CDATA[Details&nbsp;>]]></source>
         <target state="final"><![CDATA[Detalles&nbsp;>]]></target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="hideDetails">
-				<source>Hide details</source>
+        <source>Hide details</source>
         <target state="final">Esconder detalles</target>
-			</trans-unit>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/es/NodeTypes/Content/CookieGroup.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/Content/CookieGroup.xlf
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="es">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Cookie Group</source>
+        <target state="final">Grupo de cookies</target>
+			</trans-unit>
+      <trans-unit id="ui.inspector.groups.cookie.label">
+				<source>Cookie Group</source>
+        <target state="final">Grupo de cookies</target>
+			</trans-unit>
+      <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
+				<source>Insert group title...</source>
+        <target state="final">Insertar título del grupo...</target>
+			</trans-unit>
+      <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
+				<source>Insert group description...</source>
+        <target state="final">Introduzca la descripción del grupo...</target>
+			</trans-unit>
+      <trans-unit id="details">
+				<source><![CDATA[Details&nbsp;>]]></source>
+        <target state="final"><![CDATA[Detalles&nbsp;>]]></target>
+			</trans-unit>
+      <trans-unit id="hideDetails">
+				<source>Hide details</source>
+        <target state="final">Esconder detalles</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/es/NodeTypes/Content/CookieSettings.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/Content/CookieSettings.xlf
@@ -4,105 +4,114 @@
         target-language="es">
     <body>
       <trans-unit id="ui.label">
-				<source>Cookie Settings</source>
+        <source>Cookie Settings</source>
         <target state="final">Configuración de cookies</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="ui.inspector.groups.cookieSettings.label">
-				<source>Cookie Settings</source>
+        <source>Cookie Settings</source>
         <target state="final">Configuración de cookies</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
-				<source>Insert title...</source>
+        <source>Insert title...</source>
         <target state="final">Entra en la cabeza...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.mainDescription.ui.inline.editorOptions.placeholder">
-				<source>Insert description...</source>
+        <source>Insert description...</source>
         <target state="final">Introduzca la descripción...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.individualSettingsDescription.ui.inline.editorOptions.placeholder">
-				<source>Insert description...</source>
+        <source>Insert description...</source>
         <target state="final">Introduzca la descripción...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.imprintLink">
-				<source>Link to imprint</source>
+        <source>Link to imprint</source>
         <target state="final">Enlace al pie de imprenta</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.dataProtectionPolicyLink">
-				<source>Link to data protection policy</source>
+        <source>Link to data protection policy</source>
         <target state="final">Enlace a la política de privacidad</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.acceptAllButtonLabel">
-				<source>"Accept all" label</source>
+        <source>"Accept all" label</source>
         <target state="final">Etiqueta "Aceptar todo"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.saveButtonLabel">
-				<source>"Save" label</source>
+        <source>"Save" label</source>
         <target state="final">Etiqueta "Guardar"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.acceptNecessaryCookiesLabel">
-				<source>"Accept necessary cookies" label</source>
+        <source>"Accept necessary cookies" label</source>
         <target state="final">Etiqueta "Aceptar cookies necesarias"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.imprintLabel">
-				<source>"Imprint" label</source>
+        <source>"Imprint" label</source>
         <target state="final">Etiqueta "Impressum"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.dataProtectionPolicyLabel">
-				<source>"Data protection policy" label</source>
+        <source>"Data protection policy" label</source>
         <target state="final">Etiqueta "Política de privacidad"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.openIndividualSettingsLabel">
-				<source>"Individual settings" label</source>
+        <source>"Individual settings" label</source>
         <target state="final">Etiqueta "Ajustes individuales"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.closeIndividualSettingsLabel">
-				<source>"Close settings" label</source>
+        <source>"Close settings" label</source>
         <target state="final">Etiqueta "Cerrar ajustes"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.versionDate">
-				<source>Version date</source>
+        <source>Version date</source>
         <target state="final">Fecha de la versión</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.decisionTtl">
-				<source>TTL (Decision time in seconds)</source>
+        <source>TTL (Decision time in seconds)</source>
         <target state="final">TTL (tiempo de almacenamiento de la decisión en segundos)</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.decisionTtl.ui.help.message">
-				<source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1 day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)</source>
-        <target state="final">Número de segundos hasta que se vuelve a mostrar y confirmar la configuración de las cookies. Algunos valores de ejemplo son: 86400 (1 día), 604800 (1 semana), 2592000 (30 días), 31536000 (1 año).</target>
-			</trans-unit>
+        <source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1
+          day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)
+        </source>
+        <target state="final">Número de segundos hasta que se vuelve a mostrar y confirmar la configuración de las
+          cookies. Algunos valores de ejemplo son: 86400 (1 día), 604800 (1 semana), 2592000 (30 días), 31536000 (1
+          año).
+        </target>
+      </trans-unit>
       <trans-unit id="properties.closeButtonEnabled">
-				<source>Show close-button</source>
+        <source>Show close-button</source>
         <target state="final">Mostrar botón de cierre</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.closeButtonEnabled.ui.help.message">
-				<source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without making a decision. It re-appears on the next pageload.</source>
-        <target state="final">Muestra una "X" en la esquina superior derecha, si está activada. Al hacer clic en esta X, el banner se cierra sin decisión. Volverá a aparecer la próxima vez que se acceda a la página.</target>
-			</trans-unit>
+        <source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without
+          making a decision. It re-appears on the next pageload.
+        </source>
+        <target state="final">Muestra una "X" en la esquina superior derecha, si está activada. Al hacer clic en esta X,
+          el banner se cierra sin decisión. Volverá a aparecer la próxima vez que se acceda a la página.
+        </target>
+      </trans-unit>
       <trans-unit id="properties.excludedDocuments">
-				<source>Exclude for Documents</source>
+        <source>Exclude for Documents</source>
         <target state="final">Excluir para documentos</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.white">
-				<source>White</source>
+        <source>White</source>
         <target state="final">Blanco</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.black">
-				<source>Black</source>
+        <source>Black</source>
         <target state="final">Negro</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.backgroundColor">
-				<source>Background color (HEX)</source>
+        <source>Background color (HEX)</source>
         <target state="final">Color de fondo (HEX)</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.buttonTextColor">
-				<source>Button text color</source>
+        <source>Button text color</source>
         <target state="final">Color del texto del botón</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.themeColor">
-				<source>Theme color (HEX)</source>
+        <source>Theme color (HEX)</source>
         <target state="final">Color del tema (HEX)</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.maxWidth">
         <source>Maximum content width (px)</source>
         <target state="final">Anchura máxima del contenido (px)</target>

--- a/Resources/Private/Translations/es/NodeTypes/Content/CookieSettings.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/Content/CookieSettings.xlf
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="es">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Cookie Settings</source>
+        <target state="final">Configuración de cookies</target>
+			</trans-unit>
+      <trans-unit id="ui.inspector.groups.cookieSettings.label">
+				<source>Cookie Settings</source>
+        <target state="final">Configuración de cookies</target>
+			</trans-unit>
+      <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
+				<source>Insert title...</source>
+        <target state="final">Entra en la cabeza...</target>
+			</trans-unit>
+      <trans-unit id="properties.mainDescription.ui.inline.editorOptions.placeholder">
+				<source>Insert description...</source>
+        <target state="final">Introduzca la descripción...</target>
+			</trans-unit>
+      <trans-unit id="properties.individualSettingsDescription.ui.inline.editorOptions.placeholder">
+				<source>Insert description...</source>
+        <target state="final">Introduzca la descripción...</target>
+			</trans-unit>
+      <trans-unit id="properties.imprintLink">
+				<source>Link to imprint</source>
+        <target state="final">Enlace al pie de imprenta</target>
+			</trans-unit>
+      <trans-unit id="properties.dataProtectionPolicyLink">
+				<source>Link to data protection policy</source>
+        <target state="final">Enlace a la política de privacidad</target>
+			</trans-unit>
+      <trans-unit id="properties.acceptAllButtonLabel">
+				<source>"Accept all" label</source>
+        <target state="final">Etiqueta "Aceptar todo"</target>
+			</trans-unit>
+      <trans-unit id="properties.saveButtonLabel">
+				<source>"Save" label</source>
+        <target state="final">Etiqueta "Guardar"</target>
+			</trans-unit>
+      <trans-unit id="properties.acceptNecessaryCookiesLabel">
+				<source>"Accept necessary cookies" label</source>
+        <target state="final">Etiqueta "Aceptar cookies necesarias"</target>
+			</trans-unit>
+      <trans-unit id="properties.imprintLabel">
+				<source>"Imprint" label</source>
+        <target state="final">Etiqueta "Impressum"</target>
+			</trans-unit>
+      <trans-unit id="properties.dataProtectionPolicyLabel">
+				<source>"Data protection policy" label</source>
+        <target state="final">Etiqueta "Política de privacidad"</target>
+			</trans-unit>
+      <trans-unit id="properties.openIndividualSettingsLabel">
+				<source>"Individual settings" label</source>
+        <target state="final">Etiqueta "Ajustes individuales"</target>
+			</trans-unit>
+      <trans-unit id="properties.closeIndividualSettingsLabel">
+				<source>"Close settings" label</source>
+        <target state="final">Etiqueta "Cerrar ajustes"</target>
+			</trans-unit>
+      <trans-unit id="properties.versionDate">
+				<source>Version date</source>
+        <target state="final">Fecha de la versión</target>
+			</trans-unit>
+      <trans-unit id="properties.decisionTtl">
+				<source>TTL (Decision time in seconds)</source>
+        <target state="final">TTL (tiempo de almacenamiento de la decisión en segundos)</target>
+			</trans-unit>
+      <trans-unit id="properties.decisionTtl.ui.help.message">
+				<source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1 day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)</source>
+        <target state="final">Número de segundos hasta que se vuelve a mostrar y confirmar la configuración de las cookies. Algunos valores de ejemplo son: 86400 (1 día), 604800 (1 semana), 2592000 (30 días), 31536000 (1 año).</target>
+			</trans-unit>
+      <trans-unit id="properties.closeButtonEnabled">
+				<source>Show close-button</source>
+        <target state="final">Mostrar botón de cierre</target>
+			</trans-unit>
+      <trans-unit id="properties.closeButtonEnabled.ui.help.message">
+				<source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without making a decision. It re-appears on the next pageload.</source>
+        <target state="final">Muestra una "X" en la esquina superior derecha, si está activada. Al hacer clic en esta X, el banner se cierra sin decisión. Volverá a aparecer la próxima vez que se acceda a la página.</target>
+			</trans-unit>
+      <trans-unit id="properties.excludedDocuments">
+				<source>Exclude for Documents</source>
+        <target state="final">Excluir para documentos</target>
+			</trans-unit>
+      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.white">
+				<source>White</source>
+        <target state="final">Blanco</target>
+			</trans-unit>
+      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.black">
+				<source>Black</source>
+        <target state="final">Negro</target>
+			</trans-unit>
+      <trans-unit id="properties.backgroundColor">
+				<source>Background color (HEX)</source>
+        <target state="final">Color de fondo (HEX)</target>
+			</trans-unit>
+      <trans-unit id="properties.buttonTextColor">
+				<source>Button text color</source>
+        <target state="final">Color del texto del botón</target>
+			</trans-unit>
+      <trans-unit id="properties.themeColor">
+				<source>Theme color (HEX)</source>
+        <target state="final">Color del tema (HEX)</target>
+			</trans-unit>
+      <trans-unit id="properties.maxWidth">
+        <source>Maximum content width (px)</source>
+        <target state="final">Anchura máxima del contenido (px)</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/es/NodeTypes/Content/NecessarySettingGroup.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/Content/NecessarySettingGroup.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="es">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Necessary Cookies Group</source>
+        <target state="final">Grupo de cookies necesarias</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/es/NodeTypes/Content/NecessarySettingGroup.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/Content/NecessarySettingGroup.xlf
@@ -4,9 +4,9 @@
         target-language="es">
     <body>
       <trans-unit id="ui.label">
-				<source>Necessary Cookies Group</source>
+        <source>Necessary Cookies Group</source>
         <target state="final">Grupo de cookies necesarias</target>
-			</trans-unit>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/es/NodeTypes/Document/CookieSettingsPage.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/Document/CookieSettingsPage.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="es">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Cookie Settings Page</source>
+        <target state="final">Configuración de cookies</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/es/NodeTypes/Document/CookieSettingsPage.xlf
+++ b/Resources/Private/Translations/es/NodeTypes/Document/CookieSettingsPage.xlf
@@ -4,9 +4,9 @@
         target-language="es">
     <body>
       <trans-unit id="ui.label">
-				<source>Cookie Settings Page</source>
+        <source>Cookie Settings Page</source>
         <target state="final">Configuración de cookies</target>
-			</trans-unit>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Content/Cookie.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Content/Cookie.xlf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="fr">
+    <body>
+      <trans-unit id="properties.name.ui.inline.editorOptions.placeholder">
+				<source>Insert cookie name...</source>
+        <target state="final">Entrez le nom du cookie ...</target>
+			</trans-unit>
+      <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
+				<source>Insert cookie description...</source>
+        <target state="final">Entrez la description du cookie...</target>
+			</trans-unit>
+      <trans-unit id="properties.priority">
+				<source>Priority</source>
+        <target state="final">Priorité</target>
+			</trans-unit>
+      <trans-unit id="properties.priority.ui.help.message">
+				<source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier loading times.</source>
+        <target>La priorité détermine l'ordre de chargement des différents cookies. Les nombres les plus élevés garantissent des temps de chargement plus rapides.</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Content/Cookie.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Content/Cookie.xlf
@@ -4,21 +4,25 @@
         target-language="fr">
     <body>
       <trans-unit id="properties.name.ui.inline.editorOptions.placeholder">
-				<source>Insert cookie name...</source>
+        <source>Insert cookie name...</source>
         <target state="final">Entrez le nom du cookie ...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
-				<source>Insert cookie description...</source>
+        <source>Insert cookie description...</source>
         <target state="final">Entrez la description du cookie...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.priority">
-				<source>Priority</source>
+        <source>Priority</source>
         <target state="final">Priorité</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.priority.ui.help.message">
-				<source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier loading times.</source>
-        <target>La priorité détermine l'ordre de chargement des différents cookies. Les nombres les plus élevés garantissent des temps de chargement plus rapides.</target>
-			</trans-unit>
+        <source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier
+          loading times.
+        </source>
+        <target>La priorité détermine l'ordre de chargement des différents cookies. Les nombres les plus élevés
+          garantissent des temps de chargement plus rapides.
+        </target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Content/Cookie/Attribute.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Content/Cookie/Attribute.xlf
@@ -4,17 +4,17 @@
         target-language="fr">
     <body>
       <trans-unit id="ui.label">
-				<source>Cookie Attribute</source>
+        <source>Cookie Attribute</source>
         <target state="final">Caractéristiques des cookies</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.label.ui.inline.editorOptions.placeholder">
-				<source>Insert label...</source>
+        <source>Insert label...</source>
         <target state="final">Entrer le label...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.value.ui.inline.editorOptions.placeholder">
-				<source>Insert value...</source>
+        <source>Insert value...</source>
         <target state="final">Entrer une valeur...</target>
-			</trans-unit>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Content/Cookie/Attribute.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Content/Cookie/Attribute.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="fr">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Cookie Attribute</source>
+        <target state="final">Caractéristiques des cookies</target>
+			</trans-unit>
+      <trans-unit id="properties.label.ui.inline.editorOptions.placeholder">
+				<source>Insert label...</source>
+        <target state="final">Entrer le label...</target>
+			</trans-unit>
+      <trans-unit id="properties.value.ui.inline.editorOptions.placeholder">
+				<source>Insert value...</source>
+        <target state="final">Entrer une valeur...</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Content/CookieGroup.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Content/CookieGroup.xlf
@@ -4,29 +4,29 @@
         target-language="fr">
     <body>
       <trans-unit id="ui.label">
-				<source>Cookie Group</source>
+        <source>Cookie Group</source>
         <target state="final">Groupe de cookies</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="ui.inspector.groups.cookie.label">
-				<source>Cookie Group</source>
+        <source>Cookie Group</source>
         <target state="final">Groupe de cookies</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
-				<source>Insert group title...</source>
+        <source>Insert group title...</source>
         <target state="final">Insérer le titre du groupe...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
-				<source>Insert group description...</source>
+        <source>Insert group description...</source>
         <target state="final">Entrez la description du groupe...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="details">
-				<source><![CDATA[Details&nbsp;>]]></source>
+        <source><![CDATA[Details&nbsp;>]]></source>
         <target state="final"><![CDATA[Détails&nbsp;>]]></target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="hideDetails">
-				<source>Hide details</source>
+        <source>Hide details</source>
         <target state="final">Cacher les détails</target>
-			</trans-unit>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Content/CookieGroup.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Content/CookieGroup.xlf
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="fr">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Cookie Group</source>
+        <target state="final">Groupe de cookies</target>
+			</trans-unit>
+      <trans-unit id="ui.inspector.groups.cookie.label">
+				<source>Cookie Group</source>
+        <target state="final">Groupe de cookies</target>
+			</trans-unit>
+      <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
+				<source>Insert group title...</source>
+        <target state="final">Insérer le titre du groupe...</target>
+			</trans-unit>
+      <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
+				<source>Insert group description...</source>
+        <target state="final">Entrez la description du groupe...</target>
+			</trans-unit>
+      <trans-unit id="details">
+				<source><![CDATA[Details&nbsp;>]]></source>
+        <target state="final"><![CDATA[Détails&nbsp;>]]></target>
+			</trans-unit>
+      <trans-unit id="hideDetails">
+				<source>Hide details</source>
+        <target state="final">Cacher les détails</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Content/CookieSettings.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Content/CookieSettings.xlf
@@ -4,107 +4,114 @@
         target-language="fr">
     <body>
       <trans-unit id="ui.label">
-				<source>Cookie Settings</source>
+        <source>Cookie Settings</source>
         <target state="final">Paramètres des cookies</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="ui.inspector.groups.cookieSettings.label">
-				<source>Cookie Settings</source>
+        <source>Cookie Settings</source>
         <target state="final">Paramètres des cookies</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
-				<source>Insert title...</source>
+        <source>Insert title...</source>
         <target state="final">Entrer dans la tête...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.mainDescription.ui.inline.editorOptions.placeholder">
-				<source>Insert description...</source>
+        <source>Insert description...</source>
         <target state="final">Entrez la description...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.individualSettingsDescription.ui.inline.editorOptions.placeholder">
-				<source>Insert description...</source>
+        <source>Insert description...</source>
         <target state="final">Entrez la description...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.imprintLink">
-				<source>Link to imprint</source>
+        <source>Link to imprint</source>
         <target state="final">Lien vers l'impression</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.dataProtectionPolicyLink">
-				<source>Link to data protection policy</source>
+        <source>Link to data protection policy</source>
         <target state="final">Lien vers la politique de confidentialité</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.acceptAllButtonLabel">
-				<source>"Accept all" label</source>
+        <source>"Accept all" label</source>
         <target state="final">Label "Accepter tout"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.saveButtonLabel">
-				<source>"Save" label</source>
+        <source>"Save" label</source>
         <target state="final">Label "Enregistrer"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.acceptNecessaryCookiesLabel">
-				<source>"Accept necessary cookies" label</source>
+        <source>"Accept necessary cookies" label</source>
         <target state="final">Label "Accepter les cookies nécessaires"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.imprintLabel">
-				<source>"Imprint" label</source>
+        <source>"Imprint" label</source>
         <target state="final">Label "Impressum"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.dataProtectionPolicyLabel">
-				<source>"Data protection policy" label</source>
+        <source>"Data protection policy" label</source>
         <target state="final">Label "Politique de confidentialité"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.openIndividualSettingsLabel">
-				<source>"Individual settings" label</source>
+        <source>"Individual settings" label</source>
         <target state="final">Label "Paramètres individuels"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.closeIndividualSettingsLabel">
-				<source>"Close settings" label</source>
+        <source>"Close settings" label</source>
         <target state="final">Label "Fermer les paramètres"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.versionDate">
-				<source>Version date</source>
+        <source>Version date</source>
         <target state="final">Date de la version</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.decisionTtl">
-				<source>TTL (Decision time in seconds)</source>
+        <source>TTL (Decision time in seconds)</source>
         <target state="final">TTL (temps de stockage des décisions en secondes)
         </target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.decisionTtl.ui.help.message">
-				<source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1 day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)</source>
-        <target state="final">Nombre de secondes avant que les paramètres des cookies ne soient réaffichés et confirmés. Exemples de valeurs : 86400 (1 jour), 604800 (1 semaine), 2592000 (30 jours), 31536000 (1 an).</target>
-			</trans-unit>
-      <trans-unit id="properties.closeButtonEnabled">
-				<source>Show close-button</source>
-        <target state="final">Afficher le bouton de fermeture</target>
-			</trans-unit>
-      <trans-unit id="properties.closeButtonEnabled.ui.help.message">
-				<source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without making a decision. It re-appears on the next pageload.</source>
-        <target state="final">Affiche un "X" dans le coin supérieur droit, s'il est activé. En cliquant sur ce X, la bannière se ferme sans qu'aucune décision ne soit prise. Elle réapparaîtra lors du prochain accès à la page.
+        <source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1
+          day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)
+        </source>
+        <target state="final">Nombre de secondes avant que les paramètres des cookies ne soient réaffichés et confirmés.
+          Exemples de valeurs : 86400 (1 jour), 604800 (1 semaine), 2592000 (30 jours), 31536000 (1 an).
         </target>
-			</trans-unit>
+      </trans-unit>
+      <trans-unit id="properties.closeButtonEnabled">
+        <source>Show close-button</source>
+        <target state="final">Afficher le bouton de fermeture</target>
+      </trans-unit>
+      <trans-unit id="properties.closeButtonEnabled.ui.help.message">
+        <source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without
+          making a decision. It re-appears on the next pageload.
+        </source>
+        <target state="final">Affiche un "X" dans le coin supérieur droit, s'il est activé. En cliquant sur ce X, la
+          bannière se ferme sans qu'aucune décision ne soit prise. Elle réapparaîtra lors du prochain accès à la page.
+        </target>
+      </trans-unit>
       <trans-unit id="properties.excludedDocuments">
-				<source>Exclude for Documents</source>
+        <source>Exclude for Documents</source>
         <target state="final">Exclure les documents</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.white">
-				<source>White</source>
+        <source>White</source>
         <target state="final">Blanc</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.black">
-				<source>Black</source>
+        <source>Black</source>
         <target state="final">Noir</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.backgroundColor">
-				<source>Background color (HEX)</source>
+        <source>Background color (HEX)</source>
         <target state="final">Couleur d'arrière-plan (HEX)</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.buttonTextColor">
-				<source>Button text color</source>
+        <source>Button text color</source>
         <target state="final">Couleur du texte du bouton</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.themeColor">
-				<source>Theme color (HEX)</source>
+        <source>Theme color (HEX)</source>
         <target state="final">Couleur du thème (HEX)</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.maxWidth">
         <source>Maximum content width (px)</source>
         <target state="final">Largeur maximale du contenu (px)</target>

--- a/Resources/Private/Translations/fr/NodeTypes/Content/CookieSettings.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Content/CookieSettings.xlf
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="fr">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Cookie Settings</source>
+        <target state="final">Paramètres des cookies</target>
+			</trans-unit>
+      <trans-unit id="ui.inspector.groups.cookieSettings.label">
+				<source>Cookie Settings</source>
+        <target state="final">Paramètres des cookies</target>
+			</trans-unit>
+      <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
+				<source>Insert title...</source>
+        <target state="final">Entrer dans la tête...</target>
+			</trans-unit>
+      <trans-unit id="properties.mainDescription.ui.inline.editorOptions.placeholder">
+				<source>Insert description...</source>
+        <target state="final">Entrez la description...</target>
+			</trans-unit>
+      <trans-unit id="properties.individualSettingsDescription.ui.inline.editorOptions.placeholder">
+				<source>Insert description...</source>
+        <target state="final">Entrez la description...</target>
+			</trans-unit>
+      <trans-unit id="properties.imprintLink">
+				<source>Link to imprint</source>
+        <target state="final">Lien vers l'impression</target>
+			</trans-unit>
+      <trans-unit id="properties.dataProtectionPolicyLink">
+				<source>Link to data protection policy</source>
+        <target state="final">Lien vers la politique de confidentialité</target>
+			</trans-unit>
+      <trans-unit id="properties.acceptAllButtonLabel">
+				<source>"Accept all" label</source>
+        <target state="final">Label "Accepter tout"</target>
+			</trans-unit>
+      <trans-unit id="properties.saveButtonLabel">
+				<source>"Save" label</source>
+        <target state="final">Label "Enregistrer"</target>
+			</trans-unit>
+      <trans-unit id="properties.acceptNecessaryCookiesLabel">
+				<source>"Accept necessary cookies" label</source>
+        <target state="final">Label "Accepter les cookies nécessaires"</target>
+			</trans-unit>
+      <trans-unit id="properties.imprintLabel">
+				<source>"Imprint" label</source>
+        <target state="final">Label "Impressum"</target>
+			</trans-unit>
+      <trans-unit id="properties.dataProtectionPolicyLabel">
+				<source>"Data protection policy" label</source>
+        <target state="final">Label "Politique de confidentialité"</target>
+			</trans-unit>
+      <trans-unit id="properties.openIndividualSettingsLabel">
+				<source>"Individual settings" label</source>
+        <target state="final">Label "Paramètres individuels"</target>
+			</trans-unit>
+      <trans-unit id="properties.closeIndividualSettingsLabel">
+				<source>"Close settings" label</source>
+        <target state="final">Label "Fermer les paramètres"</target>
+			</trans-unit>
+      <trans-unit id="properties.versionDate">
+				<source>Version date</source>
+        <target state="final">Date de la version</target>
+			</trans-unit>
+      <trans-unit id="properties.decisionTtl">
+				<source>TTL (Decision time in seconds)</source>
+        <target state="final">TTL (temps de stockage des décisions en secondes)
+        </target>
+			</trans-unit>
+      <trans-unit id="properties.decisionTtl.ui.help.message">
+				<source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1 day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)</source>
+        <target state="final">Nombre de secondes avant que les paramètres des cookies ne soient réaffichés et confirmés. Exemples de valeurs : 86400 (1 jour), 604800 (1 semaine), 2592000 (30 jours), 31536000 (1 an).</target>
+			</trans-unit>
+      <trans-unit id="properties.closeButtonEnabled">
+				<source>Show close-button</source>
+        <target state="final">Afficher le bouton de fermeture</target>
+			</trans-unit>
+      <trans-unit id="properties.closeButtonEnabled.ui.help.message">
+				<source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without making a decision. It re-appears on the next pageload.</source>
+        <target state="final">Affiche un "X" dans le coin supérieur droit, s'il est activé. En cliquant sur ce X, la bannière se ferme sans qu'aucune décision ne soit prise. Elle réapparaîtra lors du prochain accès à la page.
+        </target>
+			</trans-unit>
+      <trans-unit id="properties.excludedDocuments">
+				<source>Exclude for Documents</source>
+        <target state="final">Exclure les documents</target>
+			</trans-unit>
+      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.white">
+				<source>White</source>
+        <target state="final">Blanc</target>
+			</trans-unit>
+      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.black">
+				<source>Black</source>
+        <target state="final">Noir</target>
+			</trans-unit>
+      <trans-unit id="properties.backgroundColor">
+				<source>Background color (HEX)</source>
+        <target state="final">Couleur d'arrière-plan (HEX)</target>
+			</trans-unit>
+      <trans-unit id="properties.buttonTextColor">
+				<source>Button text color</source>
+        <target state="final">Couleur du texte du bouton</target>
+			</trans-unit>
+      <trans-unit id="properties.themeColor">
+				<source>Theme color (HEX)</source>
+        <target state="final">Couleur du thème (HEX)</target>
+			</trans-unit>
+      <trans-unit id="properties.maxWidth">
+        <source>Maximum content width (px)</source>
+        <target state="final">Largeur maximale du contenu (px)</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Content/NecessarySettingGroup.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Content/NecessarySettingGroup.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="fr">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Necessary Cookies Group</source>
+        <target state="final">Groupe de cookies nécessaires</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Content/NecessarySettingGroup.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Content/NecessarySettingGroup.xlf
@@ -4,9 +4,9 @@
         target-language="fr">
     <body>
       <trans-unit id="ui.label">
-				<source>Necessary Cookies Group</source>
+        <source>Necessary Cookies Group</source>
         <target state="final">Groupe de cookies nécessaires</target>
-			</trans-unit>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Document/CookieSettingsPage.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Document/CookieSettingsPage.xlf
@@ -4,9 +4,9 @@
         target-language="fr">
     <body>
       <trans-unit id="ui.label">
-				<source>Cookie Settings Page</source>
+        <source>Cookie Settings Page</source>
         <target state="final">Paramètres des cookies</target>
-			</trans-unit>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/fr/NodeTypes/Document/CookieSettingsPage.xlf
+++ b/Resources/Private/Translations/fr/NodeTypes/Document/CookieSettingsPage.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="fr">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Cookie Settings Page</source>
+        <target state="final">Paramètres des cookies</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/nl/NodeTypes/Content/Cookie.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/Content/Cookie.xlf
@@ -4,21 +4,25 @@
         target-language="nl">
     <body>
       <trans-unit id="properties.name.ui.inline.editorOptions.placeholder">
-				<source>Insert cookie name...</source>
+        <source>Insert cookie name...</source>
         <target state="final">Naam cookie invoeren ...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
-				<source>Insert cookie description...</source>
+        <source>Insert cookie description...</source>
         <target state="final">Cookie beschrijving invoeren...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.priority">
-				<source>Priority</source>
+        <source>Priority</source>
         <target state="final">Prioriteit</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.priority.ui.help.message">
-				<source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier loading times.</source>
-        <target>De prioriteit bepaalt de laadvolgorde van de verschillende cookies. Hogere nummers garanderen snellere laadtijden.</target>
-			</trans-unit>
+        <source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier
+          loading times.
+        </source>
+        <target>De prioriteit bepaalt de laadvolgorde van de verschillende cookies. Hogere nummers garanderen snellere
+          laadtijden.
+        </target>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/nl/NodeTypes/Content/Cookie.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/Content/Cookie.xlf
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="nl">
+    <body>
+      <trans-unit id="properties.name.ui.inline.editorOptions.placeholder">
+				<source>Insert cookie name...</source>
+        <target state="final">Naam cookie invoeren ...</target>
+			</trans-unit>
+      <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
+				<source>Insert cookie description...</source>
+        <target state="final">Cookie beschrijving invoeren...</target>
+			</trans-unit>
+      <trans-unit id="properties.priority">
+				<source>Priority</source>
+        <target state="final">Prioriteit</target>
+			</trans-unit>
+      <trans-unit id="properties.priority.ui.help.message">
+				<source>The priority determines the loading order of the different cookies. Higher numbers guarantee earlier loading times.</source>
+        <target>De prioriteit bepaalt de laadvolgorde van de verschillende cookies. Hogere nummers garanderen snellere laadtijden.</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/nl/NodeTypes/Content/Cookie/Attribute.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/Content/Cookie/Attribute.xlf
@@ -4,17 +4,17 @@
         target-language="nl">
     <body>
       <trans-unit id="ui.label">
-				<source>Cookie Attribute</source>
+        <source>Cookie Attribute</source>
         <target state="final">Cookie kenmerk</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.label.ui.inline.editorOptions.placeholder">
-				<source>Insert label...</source>
+        <source>Insert label...</source>
         <target state="final">Label invoeren...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.value.ui.inline.editorOptions.placeholder">
-				<source>Insert value...</source>
+        <source>Insert value...</source>
         <target state="final">Waarde invoeren...</target>
-			</trans-unit>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/nl/NodeTypes/Content/Cookie/Attribute.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/Content/Cookie/Attribute.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="nl">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Cookie Attribute</source>
+        <target state="final">Cookie kenmerk</target>
+			</trans-unit>
+      <trans-unit id="properties.label.ui.inline.editorOptions.placeholder">
+				<source>Insert label...</source>
+        <target state="final">Label invoeren...</target>
+			</trans-unit>
+      <trans-unit id="properties.value.ui.inline.editorOptions.placeholder">
+				<source>Insert value...</source>
+        <target state="final">Waarde invoeren...</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/nl/NodeTypes/Content/CookieGroup.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/Content/CookieGroup.xlf
@@ -4,29 +4,29 @@
         target-language="nl">
     <body>
       <trans-unit id="ui.label">
-				<source>Cookie Group</source>
+        <source>Cookie Group</source>
         <target state="final">Cookie groep</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="ui.inspector.groups.cookie.label">
-				<source>Cookie Group</source>
+        <source>Cookie Group</source>
         <target state="final">Cookie groep</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
-				<source>Insert group title...</source>
+        <source>Insert group title...</source>
         <target state="final">Groepstitel invoegen...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
-				<source>Insert group description...</source>
+        <source>Insert group description...</source>
         <target state="final">Groepsbeschrijving invoeren...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="details">
-				<source><![CDATA[Details&nbsp;>]]></source>
+        <source><![CDATA[Details&nbsp;>]]></source>
         <target state="final"><![CDATA[Details&nbsp;>]]></target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="hideDetails">
-				<source>Hide details</source>
+        <source>Hide details</source>
         <target state="final">Details verbergen</target>
-			</trans-unit>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/nl/NodeTypes/Content/CookieGroup.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/Content/CookieGroup.xlf
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="nl">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Cookie Group</source>
+        <target state="final">Cookie groep</target>
+			</trans-unit>
+      <trans-unit id="ui.inspector.groups.cookie.label">
+				<source>Cookie Group</source>
+        <target state="final">Cookie groep</target>
+			</trans-unit>
+      <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
+				<source>Insert group title...</source>
+        <target state="final">Groepstitel invoegen...</target>
+			</trans-unit>
+      <trans-unit id="properties.description.ui.inline.editorOptions.placeholder">
+				<source>Insert group description...</source>
+        <target state="final">Groepsbeschrijving invoeren...</target>
+			</trans-unit>
+      <trans-unit id="details">
+				<source><![CDATA[Details&nbsp;>]]></source>
+        <target state="final"><![CDATA[Details&nbsp;>]]></target>
+			</trans-unit>
+      <trans-unit id="hideDetails">
+				<source>Hide details</source>
+        <target state="final">Details verbergen</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/nl/NodeTypes/Content/CookieSettings.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/Content/CookieSettings.xlf
@@ -4,105 +4,113 @@
         target-language="nl">
     <body>
       <trans-unit id="ui.label">
-				<source>Cookie Settings</source>
+        <source>Cookie Settings</source>
         <target state="final">Cookie instellingen</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="ui.inspector.groups.cookieSettings.label">
-				<source>Cookie Settings</source>
+        <source>Cookie Settings</source>
         <target state="final">Cookie instellingen</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
-				<source>Insert title...</source>
+        <source>Insert title...</source>
         <target state="final">Kop invoeren...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.mainDescription.ui.inline.editorOptions.placeholder">
-				<source>Insert description...</source>
+        <source>Insert description...</source>
         <target state="final">Beschrijving invoeren...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.individualSettingsDescription.ui.inline.editorOptions.placeholder">
-				<source>Insert description...</source>
+        <source>Insert description...</source>
         <target state="final">Beschrijving invoeren...</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.imprintLink">
-				<source>Link to imprint</source>
+        <source>Link to imprint</source>
         <target state="final">Link naar de imprint</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.dataProtectionPolicyLink">
-				<source>Link to data protection policy</source>
+        <source>Link to data protection policy</source>
         <target state="final">Link naar het privacybeleid</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.acceptAllButtonLabel">
-				<source>"Accept all" label</source>
+        <source>"Accept all" label</source>
         <target state="final">Label "Alles accepteren"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.saveButtonLabel">
-				<source>"Save" label</source>
+        <source>"Save" label</source>
         <target state="final">Label "Opslaan"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.acceptNecessaryCookiesLabel">
-				<source>"Accept necessary cookies" label</source>
+        <source>"Accept necessary cookies" label</source>
         <target state="final">Label "Accepteer noodzakelijke cookies"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.imprintLabel">
-				<source>"Imprint" label</source>
+        <source>"Imprint" label</source>
         <target state="final">Label "Impressum"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.dataProtectionPolicyLabel">
-				<source>"Data protection policy" label</source>
+        <source>"Data protection policy" label</source>
         <target state="final">Label "Privacybeleid"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.openIndividualSettingsLabel">
-				<source>"Individual settings" label</source>
+        <source>"Individual settings" label</source>
         <target state="final">Label "Individuele instellingen"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.closeIndividualSettingsLabel">
-				<source>"Close settings" label</source>
+        <source>"Close settings" label</source>
         <target state="final">Label "Instellingen sluiten"</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.versionDate">
-				<source>Version date</source>
+        <source>Version date</source>
         <target state="final">Versiedatum</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.decisionTtl">
-				<source>TTL (Decision time in seconds)</source>
+        <source>TTL (Decision time in seconds)</source>
         <target state="final">TTL (opslagtijd voor beslissingen in seconden)</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.decisionTtl.ui.help.message">
-				<source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1 day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)</source>
-        <target state="final">Aantal seconden tot de cookie-instellingen opnieuw worden weergegeven en bevestigd. Voorbeeldwaarden zijn: 86400 (1 dag), 604800 (1 week), 2592000 (30 dagen), 31536000 (1 jaar).</target>
-			</trans-unit>
+        <source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1
+          day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)
+        </source>
+        <target state="final">Aantal seconden tot de cookie-instellingen opnieuw worden weergegeven en bevestigd.
+          Voorbeeldwaarden zijn: 86400 (1 dag), 604800 (1 week), 2592000 (30 dagen), 31536000 (1 jaar).
+        </target>
+      </trans-unit>
       <trans-unit id="properties.closeButtonEnabled">
-				<source>Show close-button</source>
+        <source>Show close-button</source>
         <target state="final">Laat sluitknop zien</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.closeButtonEnabled.ui.help.message">
-				<source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without making a decision. It re-appears on the next pageload.</source>
-        <target state="final">Toont een "X" in de rechterbovenhoek, indien geactiveerd. Als je op deze X klikt, wordt de banner zonder beslissing gesloten. De volgende keer dat de pagina wordt opgeroepen, verschijnt deze weer.</target>
-			</trans-unit>
+        <source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without
+          making a decision. It re-appears on the next pageload.
+        </source>
+        <target state="final">Toont een "X" in de rechterbovenhoek, indien geactiveerd. Als je op deze X klikt, wordt de
+          banner zonder beslissing gesloten. De volgende keer dat de pagina wordt opgeroepen, verschijnt deze weer.
+        </target>
+      </trans-unit>
       <trans-unit id="properties.excludedDocuments">
-				<source>Exclude for Documents</source>
+        <source>Exclude for Documents</source>
         <target state="final">Uitsluiten voor documenten</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.white">
-				<source>White</source>
+        <source>White</source>
         <target state="final">Wit</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.black">
-				<source>Black</source>
+        <source>Black</source>
         <target state="final">Zwart</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.backgroundColor">
-				<source>Background color (HEX)</source>
+        <source>Background color (HEX)</source>
         <target state="final">Achtergrondkleur (HEX)</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.buttonTextColor">
-				<source>Button text color</source>
+        <source>Button text color</source>
         <target state="final">Knop tekstkleur</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.themeColor">
-				<source>Theme color (HEX)</source>
+        <source>Theme color (HEX)</source>
         <target state="final">Themakleur (HEX)</target>
-			</trans-unit>
+      </trans-unit>
       <trans-unit id="properties.maxWidth">
         <source>Maximum content width (px)</source>
         <target state="final">Maximale breedte inhoud (px)</target>

--- a/Resources/Private/Translations/nl/NodeTypes/Content/CookieSettings.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/Content/CookieSettings.xlf
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="nl">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Cookie Settings</source>
+        <target state="final">Cookie instellingen</target>
+			</trans-unit>
+      <trans-unit id="ui.inspector.groups.cookieSettings.label">
+				<source>Cookie Settings</source>
+        <target state="final">Cookie instellingen</target>
+			</trans-unit>
+      <trans-unit id="properties.headline.ui.inline.editorOptions.placeholder">
+				<source>Insert title...</source>
+        <target state="final">Kop invoeren...</target>
+			</trans-unit>
+      <trans-unit id="properties.mainDescription.ui.inline.editorOptions.placeholder">
+				<source>Insert description...</source>
+        <target state="final">Beschrijving invoeren...</target>
+			</trans-unit>
+      <trans-unit id="properties.individualSettingsDescription.ui.inline.editorOptions.placeholder">
+				<source>Insert description...</source>
+        <target state="final">Beschrijving invoeren...</target>
+			</trans-unit>
+      <trans-unit id="properties.imprintLink">
+				<source>Link to imprint</source>
+        <target state="final">Link naar de imprint</target>
+			</trans-unit>
+      <trans-unit id="properties.dataProtectionPolicyLink">
+				<source>Link to data protection policy</source>
+        <target state="final">Link naar het privacybeleid</target>
+			</trans-unit>
+      <trans-unit id="properties.acceptAllButtonLabel">
+				<source>"Accept all" label</source>
+        <target state="final">Label "Alles accepteren"</target>
+			</trans-unit>
+      <trans-unit id="properties.saveButtonLabel">
+				<source>"Save" label</source>
+        <target state="final">Label "Opslaan"</target>
+			</trans-unit>
+      <trans-unit id="properties.acceptNecessaryCookiesLabel">
+				<source>"Accept necessary cookies" label</source>
+        <target state="final">Label "Accepteer noodzakelijke cookies"</target>
+			</trans-unit>
+      <trans-unit id="properties.imprintLabel">
+				<source>"Imprint" label</source>
+        <target state="final">Label "Impressum"</target>
+			</trans-unit>
+      <trans-unit id="properties.dataProtectionPolicyLabel">
+				<source>"Data protection policy" label</source>
+        <target state="final">Label "Privacybeleid"</target>
+			</trans-unit>
+      <trans-unit id="properties.openIndividualSettingsLabel">
+				<source>"Individual settings" label</source>
+        <target state="final">Label "Individuele instellingen"</target>
+			</trans-unit>
+      <trans-unit id="properties.closeIndividualSettingsLabel">
+				<source>"Close settings" label</source>
+        <target state="final">Label "Instellingen sluiten"</target>
+			</trans-unit>
+      <trans-unit id="properties.versionDate">
+				<source>Version date</source>
+        <target state="final">Versiedatum</target>
+			</trans-unit>
+      <trans-unit id="properties.decisionTtl">
+				<source>TTL (Decision time in seconds)</source>
+        <target state="final">TTL (opslagtijd voor beslissingen in seconden)</target>
+			</trans-unit>
+      <trans-unit id="properties.decisionTtl.ui.help.message">
+				<source>Number of seconds until cookie settings are displayed and confirmed again. Example values are: 86400 (1 day), 604800 (1 week), 2592000 (30 days), 31536000 (1 year)</source>
+        <target state="final">Aantal seconden tot de cookie-instellingen opnieuw worden weergegeven en bevestigd. Voorbeeldwaarden zijn: 86400 (1 dag), 604800 (1 week), 2592000 (30 dagen), 31536000 (1 jaar).</target>
+			</trans-unit>
+      <trans-unit id="properties.closeButtonEnabled">
+				<source>Show close-button</source>
+        <target state="final">Laat sluitknop zien</target>
+			</trans-unit>
+      <trans-unit id="properties.closeButtonEnabled.ui.help.message">
+				<source>Shows an "X" on the right top of the banner, if enabled. A click on the X hides the banner, but without making a decision. It re-appears on the next pageload.</source>
+        <target state="final">Toont een "X" in de rechterbovenhoek, indien geactiveerd. Als je op deze X klikt, wordt de banner zonder beslissing gesloten. De volgende keer dat de pagina wordt opgeroepen, verschijnt deze weer.</target>
+			</trans-unit>
+      <trans-unit id="properties.excludedDocuments">
+				<source>Exclude for Documents</source>
+        <target state="final">Uitsluiten voor documenten</target>
+			</trans-unit>
+      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.white">
+				<source>White</source>
+        <target state="final">Wit</target>
+			</trans-unit>
+      <trans-unit id="properties.buttonTextColor.selectBoxEditor.values.black">
+				<source>Black</source>
+        <target state="final">Zwart</target>
+			</trans-unit>
+      <trans-unit id="properties.backgroundColor">
+				<source>Background color (HEX)</source>
+        <target state="final">Achtergrondkleur (HEX)</target>
+			</trans-unit>
+      <trans-unit id="properties.buttonTextColor">
+				<source>Button text color</source>
+        <target state="final">Knop tekstkleur</target>
+			</trans-unit>
+      <trans-unit id="properties.themeColor">
+				<source>Theme color (HEX)</source>
+        <target state="final">Themakleur (HEX)</target>
+			</trans-unit>
+      <trans-unit id="properties.maxWidth">
+        <source>Maximum content width (px)</source>
+        <target state="final">Maximale breedte inhoud (px)</target>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/nl/NodeTypes/Content/NecessarySettingGroup.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/Content/NecessarySettingGroup.xlf
@@ -4,9 +4,9 @@
         target-language="nl">
     <body>
       <trans-unit id="ui.label">
-				<source>Necessary Cookies Group</source>
+        <source>Necessary Cookies Group</source>
         <target state="final">Noodzakelijke cookies groep</target>
-			</trans-unit>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/nl/NodeTypes/Content/NecessarySettingGroup.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/Content/NecessarySettingGroup.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="nl">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Necessary Cookies Group</source>
+        <target state="final">Noodzakelijke cookies groep</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Translations/nl/NodeTypes/Document/CookieSettingsPage.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/Document/CookieSettingsPage.xlf
@@ -4,9 +4,9 @@
         target-language="nl">
     <body>
       <trans-unit id="ui.label">
-				<source>Cookie Settings Page</source>
+        <source>Cookie Settings Page</source>
         <target state="final">Cookie instellingen</target>
-			</trans-unit>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Translations/nl/NodeTypes/Document/CookieSettingsPage.xlf
+++ b/Resources/Private/Translations/nl/NodeTypes/Document/CookieSettingsPage.xlf
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file original="" product-name="KaufmannDigital.GDPR.CookieConsent" source-language="en" datatype="plaintext"
+        target-language="nl">
+    <body>
+      <trans-unit id="ui.label">
+				<source>Cookie Settings Page</source>
+        <target state="final">Cookie instellingen</target>
+			</trans-unit>
+    </body>
+  </file>
+</xliff>


### PR DESCRIPTION
Adds a missing language label, adds a few languages and cleans up some of the xlf files.

I would suggest to remove the `xml:space="preserve"` attributes throughout all languages files. Happy to do this.

Fixes: #57 