### PR TITLE
TASK: Initialize.js makes loadCookiebannerHtml parameters explicit

### DIFF
--- a/Resources/Public/JavaScript/Initialize.js
+++ b/Resources/Public/JavaScript/Initialize.js
@@ -92,12 +92,12 @@ if (typeof KD_GDPR_CC !== 'undefined' && KD_GDPR_CC.documentNodeDisabled === fal
     var decisionExpiry = cookieConsentDate.getTime() + KD_GDPR_CC.decisionTtl;
 
     if (versionDate > cookieConsentDate && window.neos === undefined) {
-        loadCookiebannerHtml();
+        loadCookiebannerHtml(false, false, false);
     } else if (!Array.isArray(cookieObject.consents) && !cookieObject.consents[KD_GDPR_CC.dimensionsIdentifier]) {
-        loadCookiebannerHtml();
+        loadCookiebannerHtml(false, false, false);
     } else if (KD_GDPR_CC.decisionTtl > 0 && decisionExpiry < new Date()) {
         //Re-Open Cookie-Consent, if TTL is expired
-        loadCookiebannerHtml(true);
+        loadCookiebannerHtml(true, false, false);
     }
 
 
@@ -109,7 +109,7 @@ if (typeof KD_GDPR_CC !== 'undefined' && KD_GDPR_CC.documentNodeDisabled === fal
     });
 } else if (typeof KD_GDPR_CC !== 'undefined' && KD_GDPR_CC.documentNodeDisabled === false && document.getElementsByClassName('gdpr-cookieconsent-settings').length === 0 && window.neos === undefined) {
     /*No Cookie set, not in backend & not on cookie page*/
-    loadCookiebannerHtml();
+    loadCookiebannerHtml(false, false, false);
 }
 
 var links = document.querySelectorAll('a[href*=\"#GDPR-CC-open-settings\"]');


### PR DESCRIPTION
The feature `hideBeforeInteraction` does not work, because, currently, the parameters for `loadCookiebannerHtml` are used in strict equality comparision, e.g. [here](https://github.com/KaufmannDigital/KaufmannDigital.GDPR.CookieConsent/blob/master/Resources/Public/JavaScript/Initialize.js#L35), but most of the time, [no parameters are given at all](https://github.com/KaufmannDigital/KaufmannDigital.GDPR.CookieConsent/blob/master/Resources/Public/JavaScript/Initialize.js#L95), which causes the comparision to fail, because `undefined !== false`.  
This PR set the parameters for `loadCookiebannerHtml` explicit to `false` causing `hideBeforeInteraction` to function correctly.